### PR TITLE
Clean documentation of unnecessary words

### DIFF
--- a/API/README.md
+++ b/API/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Vortex API provides a beautiful, unified singleton interface to all component handlers in the HardFOC Vortex platform. It implements lazy initialization with proper dependency management, ensuring all systems are properly initialized in the correct order before exposing them to the user.
+The Vortex API provides a unified singleton interface to all component handlers in the HardFOC Vortex platform. It implements lazy initialization with proper dependency management, ensuring all systems are properly initialized in the correct order before exposing them to the user.
 
 ## 🏗️ Architecture
 
@@ -336,4 +336,4 @@ This API is part of the HardFOC HAL and follows the same licensing terms.
 
 ---
 
-**The Vortex API provides a beautiful, unified interface to the entire HardFOC platform, making it easy to access all components through a single, well-designed interface.** 
+**The Vortex API provides a unified interface to the entire HardFOC platform, making it easy to access all components through a single, well-designed interface.** 

--- a/README.md
+++ b/README.md
@@ -17,16 +17,16 @@
 
 ## 🎯 Overview
 
-The HardFOC HAL provides a comprehensive, thread-safe hardware abstraction layer specifically designed for the **HardFOC Vortex V1** motor controller board. The system features the **Vortex API** - a beautiful, unified singleton interface that provides seamless access to all component handlers including GPIO, ADC, communication interfaces, motor controllers, IMU sensors, encoders, LED management, and temperature monitoring.
+The HardFOC HAL provides a comprehensive, thread-safe hardware abstraction layer specifically designed for the **HardFOC Vortex V1** motor controller board. The system features the **Vortex API** - a unified singleton interface that provides access to all component handlers including GPIO, ADC, communication interfaces, motor controllers, IMU sensors, encoders, LED management, and temperature monitoring.
 
-The **Vortex API** is named after the **HardFOC Vortex V1** board, providing a unified interface that mirrors the board's integrated design philosophy where all components work together seamlessly.
+The **Vortex API** is named after the **HardFOC Vortex V1** board, providing a unified interface that mirrors the board's integrated design philosophy where all components work together.
 
 ### ✨ Key Features
 
 - **🔌 Vortex API**: Unified singleton interface to all system components
 - **🏗️ HardFOC Vortex V1 Optimized**: Specifically designed for the Vortex V1 board
 - **🔧 Unified Hardware Management**: Single API for GPIO, ADC, SPI, I2C, UART, and CAN
-- **🎛️ Multi-Source Support**: ESP32-C6, PCAL95555, TMC9660 seamlessly integrated
+- **🎛️ Multi-Source Support**: ESP32-C6, PCAL95555, TMC9660 integrated
 - **🔒 Thread-Safe Operations**: Concurrent access from multiple tasks
 - **📊 Advanced Diagnostics**: Real-time health monitoring and error tracking
 - **⚡ High Performance**: Optimized batch operations and interrupt handling
@@ -36,9 +36,9 @@ The **Vortex API** is named after the **HardFOC Vortex V1** board, providing a u
 
 ## 🔌 Vortex API - Unified System Interface
 
-The **Vortex API** is the heart of the HardFOC Vortex V1 system, providing a beautiful, unified interface to all component handlers. Named after the **HardFOC Vortex V1** board, it implements lazy initialization with proper dependency management, ensuring all systems are properly initialized in the correct order.
+The **Vortex API** is the heart of the HardFOC Vortex V1 system, providing a unified interface to all component handlers. Named after the **HardFOC Vortex V1** board, it implements lazy initialization with proper dependency management, ensuring all systems are properly initialized in the correct order.
 
-The API design mirrors the **Vortex V1** board's philosophy of integrated, seamless operation where all components work together as a unified system rather than separate modules.
+The API design mirrors the **Vortex V1** board's philosophy of integrated operation where all components work together as a unified system rather than separate modules.
 
 ### 🏗️ Vortex API Architecture
 
@@ -692,6 +692,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 [⭐ Star us on GitHub](https://github.com/hardfoc/hf-hal-vortex-v1) • [🐛 Report Bug](https://github.com/hardfoc/hf-hal-vortex-v1/issues) • [💡 Request Feature](https://github.com/hardfoc/hf-hal-vortex-v1/issues)
 
-**The Vortex API provides a beautiful, unified interface to the HardFOC Vortex V1 board!**
+**The Vortex API provides a unified interface to the HardFOC Vortex V1 board!**
 
 </div>

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The **Vortex API** is named after the **HardFOC Vortex V1** board, providing a u
 - **🔌 Vortex API**: Unified singleton interface to all system components
 - **🏗️ HardFOC Vortex V1 Optimized**: Specifically designed for the Vortex V1 board
 - **🔧 Unified Hardware Management**: Single API for GPIO, ADC, SPI, I2C, UART, and CAN
-- **🎛️ Multi-Source Support**: ESP32-C6, PCAL95555, TMC9660 integrated
+- **🎛️ Multi-Source Support**: ESP32-C6, PCAL95555, TMC9660, BNO08x, AS5047U, NTC thermistors, WS2812 LEDs integrated
 - **🔒 Thread-Safe Operations**: Concurrent access from multiple tasks
 - **📊 Advanced Diagnostics**: Real-time health monitoring and error tracking
 - **⚡ High Performance**: Optimized batch operations and interrupt handling


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove subjective adjectives and marketing language from documentation to improve technical precision.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR removes words like "beautiful", "seamless", and "seamlessly" that were identified as unnecessary or marketing-oriented, making the documentation more factual and professional.

---
<a href="https://cursor.com/background-agent?bcId=bc-3fc51b9b-920f-44e0-993f-e1fd3fc77942">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3fc51b9b-920f-44e0-993f-e1fd3fc77942">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>